### PR TITLE
adds _8 to literal constants in tea_solve.f90

### DIFF
--- a/tea_solve.f90
+++ b/tea_solve.f90
@@ -190,8 +190,8 @@ SUBROUTINE tea_leaf()
               max_iters, n-1, info)
           first=.FALSE.
           IF (info .NE. 0) CALL report_error('tea_leaf', 'Error in calculating eigenvalues')
-          eigmin = eigmin * 0.95
-          eigmax = eigmax * 1.05
+          eigmin = eigmin * 0.95_8
+          eigmax = eigmax * 1.05_8
         ENDIF
 
         IF (tl_use_chebyshev) THEN


### PR DESCRIPTION
otherwise they are not treated as doubles? But the result is definitely different